### PR TITLE
Updates

### DIFF
--- a/libraries/teensy/CWKeyerShield/CWKeyerShield.cpp
+++ b/libraries/teensy/CWKeyerShield/CWKeyerShield.cpp
@@ -41,13 +41,23 @@ void CWKeyerShield::setup(void)
     if (Pin_MasterVolume      >= 0) pinMode(Pin_MasterVolume,      INPUT);
     if (Pin_Speed             >= 0) pinMode(Pin_Speed,             INPUT);
 
-    sine.frequency(default_freq);
-    sine_level=default_level;
-    sine.amplitude(sine_level);
+    if (Pin_PTTin             >= 0) pinMode(Pin_PTTin,             INPUT_PULLUP);
+    if (Pin_PTTout            >= 0) pinMode(Pin_PTTout,            OUTPUT);
+    if (Pin_CWout             >= 0) pinMode(Pin_CWout,             OUTPUT);
+
+    //
+    // The following settings will probably very soon be overwritten,
+    // but let us start with some 'safe' values
+    //
+
+    sine.frequency(800.0F);
+    sine.amplitude(0.2F);
 
     if (wm8960) {
       wm8960->enable();
       wm8960->volume(0.8F);
+      wm8960->inputSelect(0);             // select and activate microphone input
+      wm8960->inputLevel(0.1F, 0.1F);     // volume control for mic input (both mic and MEMS)
     }
     if (sgtl5000) {
       sgtl5000->enable();
@@ -66,9 +76,49 @@ void CWKeyerShield::setup(void)
 void CWKeyerShield::loop(void)
 {
     if (enable_pots) { pots(); }
+    monitor_ptt();
     midi();
 }
 
+void CWKeyerShield::monitor_ptt(void)
+{
+    //
+    // do a de-bouncing read of the ptt digital input
+    // combine this with the cwptt flag
+    // if PTT status changed, send PTT MIDI message
+    // and toggle status of hardware PTT out
+    //
+    unsigned long now=millis();
+    int val;
+
+    if (now > (last_ptt_read + 10) && (Pin_PTTin >= 0)) {
+      val=!digitalRead(Pin_PTTin);         // input is active-low
+      if (val != last_ptt_in) {
+        last_ptt_in=val;
+        last_ptt_read = now;               // used for debouncing
+      }
+    }
+    val  = (last_ptt_in | cwptt_state) ? 1 : 0;
+    if (val != midiptt_state) {
+      midiptt_state = val;
+      midiptt(val);
+    }
+    //
+    // if micptt_hwptt is not set, this suppresses signalling
+    // the PTT-in state to the PTT-out line, but MIDI PTT
+    // reporting should still occur.
+    //
+    // if cwptt_hwptt is not set, this suppresses signalling
+    // the cwptt state to the PTT-out line, but MIDI PTT
+    // reporting should still occur
+    //
+    //
+    val = ((last_ptt_in & micptt_hwptt) | (cwptt_state & cwptt_hwptt)) ? 1 : 0;
+    if (val != hwptt_state) {
+      hwptt_state = val;
+      hwptt(val);
+    }
+}
 
 void CWKeyerShield::midi(void)
 {
@@ -84,23 +134,25 @@ void CWKeyerShield::midi(void)
         if (usbMIDI.getType() == usbMIDI.ControlChange) {
             cmd  = usbMIDI.getData1();
             data = usbMIDI.getData2();
+            data = data & 0x7F; // paranoia
 
-        Serial.print("MIDI ");
-        Serial.print(usbMIDI.getChannel());
-        Serial.print(" ");
-        Serial.print(midi_rx_ch);
-        Serial.print(" ");
-        Serial.print(cmd);
-        Serial.print(" ");
-        Serial.println(data);
+        //Serial.print("MIDI ");
+        //Serial.print(usbMIDI.getChannel());
+        //Serial.print(" ");
+        //Serial.print(midi_controller_ch);
+        //Serial.print(" ");
+        //Serial.print(cmd);
+        //Serial.print(" ");
+        //Serial.println(data);
 
 
         // Accept setting of control channel on any channel
-        if (cmd == MIDI_RX_CH) {
-            midi_rx_ch = data & 0x0f;
+        if (cmd == MIDI_CONTROLLER_CH) {
+            if (data > 16) data=0;
+            set_midi_controller_ch(data);
         }
 
-        if (usbMIDI.getChannel() == midi_rx_ch) {
+        if (usbMIDI.getChannel() == midi_controller_ch) {
             switch(cmd) {
                 case MIDI_SET_A:
                     accum_a = data;
@@ -115,15 +167,15 @@ void CWKeyerShield::midi(void)
                     break;
 
                 case MIDI_MASTER_VOLUME:
-                    mastervolume((data << 6)+31);
+                    mastervolume(data);
                     break;
 
                 case MIDI_SIDETONE_VOLUME:
-                    sidetonevolume((data << 6)+31);
+                    sidetonevolume(data);
                     break;
 
                 case MIDI_SIDETONE_FREQUENCY:
-                    sidetonefrequency((data << 6)+31);
+                    sidetonefrequency(data);
                     break;
 
                 case MIDI_CW_SPEED:
@@ -159,37 +211,45 @@ void CWKeyerShield::midi(void)
                     micptt_hwptt = (data != 0);
                     break;
 
-                case MIDI_TX_CH:
-                    midi_tx_ch = data & 0x0f;
+                case MIDI_CWPTT_HWPTT:
+                    cwptt_hwptt = (data != 0);
                     break;
 
+                case MIDI_RADIO_CH:
+                    //
+                    // If the value is zero or > 16, 
+                    // this will switch off *all* communication
+                    // on the "radio" channel
+                    //
+                    if (data > 16) data=0;
+                    midi_radio_ch = data;
+                    break;
+
+                //
+                // The Note/Controller values for the communication
+                // which the radio range from 0-127.
+                // We will never send a MIDI message with a note or
+                // controller of zero, so this value can be used to
+                // switch off the corresponding message
+                //
                 case MIDI_KEYDOWN_NOTE:
                     midi_keydown_note = data;
                     break;
 
-                case MIDI_PTT_MIC_NOTE:
-                    midi_ptt_mic_note = data;
+                case MIDI_PTT_NOTE:
+                    midi_ptt_note = data;
                     break;
 
-                case MIDI_PTT_IN_NOTE:
-                    midi_ptt_in_note = data;
+                case MIDI_SPEED_CTRL:
+                    midi_speed_ctrl = data;
                     break;
 
-                // There is currently no way to disable the note once set
-                case MIDI_CWPTT_NOTE:
-                    midi_cwptt_note = data;
+                case MIDI_FREQ_CTRL:
+                    midi_freq_ctrl = data;
                     break;
-
-                //case MIDI_SPEED_CTRL:
-                //    midi_speed_ctrl = data;
-                //    break;
-
-                //case MIDI_FREQ_CTRL:
-                //    midi_freq_ctrl = data;
-                //    break;
 
                 case MIDI_RESPONSE:
-                    midi_response = data;
+                    midi_controller_response = (data != 0);
                     break;
 
                 case MIDI_WM8960_ENABLE:
@@ -300,135 +360,45 @@ void CWKeyerShield::midi(void)
 }
 }
 
-
-#ifdef DL1YCF_POTS
-
-void CWKeyerShield::pots() {
-    unsigned long now;
-    //
-    // handle analog lines, but only one analogRead every 5 msec
-    // in case of overflow, trigger read.
-    // Read all four input lines in round-robin fashion
-    //
-    now = millis();
-    if (now < last_analog_read) last_analog_read = now; // overflow recovery
-    if (now > last_analog_read +5) {
-      last_analog_read = now;
-      switch (last_analog_line++) {
-        case 0:  // SideToneFrequency
-          if (Pin_SideToneFrequency >= 0) {
-            if (analogDenoise(Pin_SideToneFrequency, &Analog_SideFreq, &last_sidefreq)) {
-              sidetonefrequency(400+30*last_sidefreq);  // 400 ... 1000 Hz in 30 Hz steps
-            }
-          }
-          break;
-        case 1: // SideToneVolume
-          if (Pin_SideToneVolume >= 0) {
-            if (analogDenoise(Pin_SideToneVolume, &Analog_SideVol, &last_sidevol)) {
-              sidetonevolume(last_sidevol);
-            }
-          }
-          break;
-        case 2: // Master Volume
-          if (Pin_MasterVolume >= 0) {
-            if (analogDenoise(Pin_MasterVolume, &Analog_MasterVol, &last_mastervol)) {
-              mastervolume(last_mastervol);
-            }
-          }
-          break;
-        case 3: // Speed
-          if (Pin_Speed >= 0) {
-            if (analogDenoise(Pin_Speed, &Analog_Speed, &last_speed)) {
-              speed_set(10+last_speed); // report to keyer
-              cwspeed(10+last_speed);   // report to radio
-            }
-          }
-          last_analog_line=0;   // roll over
-          break;
-      }
-    }
-}
-
-bool CWKeyerShield::analogDenoise(int pin, uint16_t *value, uint8_t *old) {
-  //
-  // Read analog input from pin #pin, convert value to a scale 0-20.
-  // "old" and "value" need to be conserved between calls.
-  // "value" is needed for low-passing, and "old" is given the new
-  // reading in the range 0-20 if the analog input value has changed.
-  // This function returns "true" if the value has changed, and "false"
-  // if there is no update.
-  //
-  // Here comes DL1YCF's "black magic" to de-noise the analog input:
-  //
-  // The result of analogRead() is low-passed through a moving exponential average.
-  // The result of the low-passing is stored in "value" and is in the range
-  // (0, 163368) for 10-bit analog reads (16368 = 16*1023).
-  //
-  // The value is then converted to the scale 0-20 and the new scale value
-  // is stored in *old. The conversion is done as follows:
-  //
-  // value =     0 ...   779   ==> reading =  0
-  // value =   780 ...  1559   ==> reading =  1
-  // ...
-  // value = 15600 ... 16368   ==> reading = 20
-  //
-  // In this section: VALUE is the low-passed analog reading in the
-  // range 0...16386, while READING is the returned value in the range
-  // 0..20.
-  // While the exponential averaging implements a low-pass filter so we get
-  // rid of high-frequency oscillations in VALUE, we have to guard
-  // against small-amplitude low-frequency oscillations as well. These can
-  // occur if VALUE is close to a multiple of 780 (that is, close to the
-  // border of two intervals leading to different READINGs).
-  // So we remember the previous READING, compute the mid-point of the
-  // interval of VALUEs that possibly lead to this READING, and require that
-  // the new VALUE differs from that midpoint by at least 600.
-  // This means, if the pot is close to the borderline, we have to move the pot
-  // away from this borderline before reporting a new READING.
-  //
-  // We have to do this, because slowly varying READINGs for the same
-  // pot position are quite unpleasant, especially if it affects the
-  // side tone frequency.
-  //
-
-  uint16_t newval, midpoint;
-
-  if (pin < 0) return false; // paranoia
-
-  newval = (15 * *value) / 16 + analogRead(pin);  // range 0 - 16368
-  if (newval > 16368) newval=16368; // pure paranoia
-  *value = newval;
-
-  midpoint = 390 + 780 * *old;  // midpoint of interval corresponding to "old" value
-
-  if (newval > midpoint + 600 || (midpoint > 780 && newval < midpoint - 600)) {
-    *old = newval / 780; // range 0 ... 20
-    return true;
-  } else {
-    return false;
-  }
-}
-
-#else
-
 void CWKeyerShield::pots()
 {
     uint16_t analog_data;
     unsigned long m = millis();
+    int val;
 
     // Call every 10 ms, will handle rollover as both m and last_analog_read are unsigned long
     if ((m - last_analog_read) > 10) {
-
+        //
+        // Note on analog debouncing:
+        // The value obtained by analogRead is a 12-bit value, that is converted
+        // to a 13-bit moving average (0...8191). Changes of the input value are
+        // 'accepted' if they deviate more than a given threshold (64 for volume,
+        // 128 for freq and 256 for speed) from the previous 'nominal' value
+        // (this is referred to as 'discretization').
+        //
+        // Now there is a problem:
+        // Let the "discretization" be 64 (as for the volume pots). Then, if the
+        // "last analog value" was 64 (mapping to 1 on the range 0-127), you can never
+        // reach zero. Likewise, if the "last analog value" was 63 (mapping to 0),
+        // then it is impossible to reach the next value and you have to jump 2 steps.
+        // Therefore, the last analog value to be remembered will be placed
+        // at the mid-point of the interval corresponding to the new setting.
+        // (in our example:  63 ==> 32; 64 ==> 96).
+        //
+        // Note on the soldering of the pots:
+        // In the CW Keyer Shield, the pots are soldered such that turning them clockwise
+        // *decreases* the analogRead value downto zero. Therefore the max analog value
+        // is a "zero reading" and a zero analog value is a "max reading".
+        //
         if (last_analog_line == 0) {
             // Master volume
             analog_data = analogRead(Pin_MasterVolume);
-            // At 12 bit this averaging will produce a value in the 0 to 8191 range, 13 bits
             Analog_MasterVol = (Analog_MasterVol >> 1) + analog_data;
 
-            // Volume is 80 values, so only care if more than about 2**7 bit change
             if (abs(Analog_MasterVol - last_mastervol) > 64) {
-                mastervolume(8191-Analog_MasterVol);
-                last_mastervol = Analog_MasterVol;
+                val=(Analog_MasterVol >> 6) & 0x7f;              // 0...127
+                mastervolume(127-val);                           // correct soldering
+                last_mastervol = (val << 6) + 32;                // new "old" value
                 //Serial.print("MV ");
                 //Serial.println(analog_data);
             }
@@ -437,10 +407,10 @@ void CWKeyerShield::pots()
             // Sidetone volume
             analog_data = analogRead(Pin_SideToneVolume);
             Analog_SideVol = (Analog_SideVol >> 1) + analog_data;
-            // Sidetone volume has 32 entries so 5 bits
-            if (abs(Analog_SideVol - last_sidevol) > 256) {
-                sidetonevolume(8191-Analog_SideVol);
-                last_sidevol = Analog_SideVol;
+            if (abs(Analog_SideVol - last_sidevol) > 64) {
+                val=(Analog_SideVol >> 6) & 0x7F;                // 0...127
+                sidetonevolume(127-val);                         // correct soldering
+                last_sidevol = (val << 6) + 32;                  // new "old" value
                 //Serial.print("SV ");
                 //Serial.println(analog_data);
             }
@@ -449,11 +419,10 @@ void CWKeyerShield::pots()
             // Sidetone frequency
             analog_data = analogRead(Pin_SideToneFrequency);
             Analog_SideFreq = (Analog_SideFreq >> 1) + analog_data;
-            // Range between 250 and 1274, 10 bits
-            if (abs(Analog_SideFreq - last_sidefreq) > 64) {
-                // Range between 100 and 2147 hz
-                sidetonefrequency(8191-Analog_SideFreq);
-                last_sidefreq = Analog_SideFreq;
+            if (abs(Analog_SideFreq - last_sidefreq) > 128) {
+                val=(Analog_SideFreq >> 7) & 0x3F;               // val 0...63, mapped to 40 ... 103 (400 to 1030 Hz)
+                sidetonefrequency(103-val);                      // correct soldering
+                last_sidefreq = (val << 7) + 64;                 // new "old" value
                 //Serial.print("SF ");
                 //Serial.println(analog_data);
             }
@@ -462,17 +431,12 @@ void CWKeyerShield::pots()
             // Speed
             analog_data = analogRead(Pin_Speed);
             Analog_Speed = (Analog_Speed >> 1) + analog_data;
-            // range between 1 and 65 WPM via pot, 6 bits
-            if (abs(Analog_Speed - last_speed) > 128) {
-                uint16_t spd=(8191-Analog_Speed)>>7;
-                // never report a "zero speed"
-                if (spd < 1) spd=1;
-                speed_set(spd); // report to keyer
-                cwspeed(spd);   // report to radio
-                last_speed = Analog_Speed;
+            if (abs(Analog_Speed - last_speed) > 256) {
+                val=(Analog_Speed >> 8) & 0x1f;                  // 0...31, mapped to 0 ... 127 through SpeedTab
+                speed_set(SpeedTab[31-val]);                     // report to keyer
+                cwspeed(SpeedTab[31-val]);                       // report to radio
+                last_speed = (val << 8) + 128;                   // new "old" value
                 //Serial.print("SP ");
-                //Serial.println(pot_speed);
-                //Serial.print(" ");
                 //Serial.println(analog_data);
             }
         }
@@ -482,47 +446,43 @@ void CWKeyerShield::pots()
     }
 }
 
-#endif
-
-
-void CWKeyerShield::key(int state)
-{
-    //
-    // Interface to the keyer. The keyer calls this if it wants
-    // to do key-down or key-up
-    //
-    teensyaudiotone.setTone(state);
-    if (midi_keydown_note >= 0 && midi_tx_ch > 0) {
-        usbMIDI.sendNoteOn(midi_keydown_note, state ? 127 : 0, midi_tx_ch);
-        usbMIDI.send_now();
-    }
-}
-
 void CWKeyerShield::hwptt(int state)
 {
     //
-    // Trigger hardware PTT line
-    // TODO. HW digital pin not yet known!
+    // Set the hardware PTT line
     //
+    if (Pin_PTTout > 0) {
+      digitalWrite(Pin_PTTout, state ? 1 : 0);
+    }
 }
 
 void CWKeyerShield::midiptt(int state)
 {
     //
-    // Send MIDI "PTT" event
+    // send MIDI PTT message to radio
     //
-    if (midi_cwptt_note >= 0 && midi_tx_ch > 0) {
-        usbMIDI.sendNoteOn(midi_cwptt_note, state ? 127 : 0, midi_tx_ch);
+    if (midi_ptt_note > 0 && midi_radio_ch > 0) {
+        usbMIDI.sendNoteOn(midi_ptt_note, state ? 127 : 0, midi_radio_ch);
     }
 }
 
-void CWKeyerShield::micptt(int state)
+void CWKeyerShield::key(int state)
 {
     //
-    // This function is called if the MICPTT input line state changes
+    // Interface to the keyer, to trigger key-up and key-down
     //
-    if (micptt_hwptt) hwptt(state);
-    midiptt(state);
+    // a) switch side tone on/off
+    // b) send MIDI message
+    // c) set hardware line
+    //
+    teensyaudiotone.setTone(state);
+    if (midi_keydown_note > 0 && midi_radio_ch > 0) {
+        usbMIDI.sendNoteOn(midi_keydown_note, state ? 127 : 0, midi_radio_ch);
+        usbMIDI.send_now();
+    }
+    if (Pin_CWout >= 0) {
+      digitalWrite(Pin_CWout, state? 1 : 0);
+    }
 }
 
 void CWKeyerShield::cwptt(int state)
@@ -533,83 +493,67 @@ void CWKeyerShield::cwptt(int state)
     //
     if (mute_on_cwptt || state == 0) {
       //
-      // This mutes the audio from the PC but not the side tone
+      // possibly mute the audio from the PC (but not the side tone)
       //
       teensyaudiotone.muteAudioIn(state);
     }
-    hwptt(state);   // if already done in the keyer, this does no harm
-    midiptt(state);
+    cwptt_state = state;  // Actual PTT setting is done in monitor_ptt()
 }
 
 
-// Expected level is 0 to 8191
-void CWKeyerShield::mastervolume(uint16_t level)
+void CWKeyerShield::mastervolume(uint8_t level)  // input level from 0 ... 127
 {
-    // Ease reaching max and minimum values
-    if (level > 8158) level = 8191;
-    if (level < 33) level = 0;
-
-    if (midi_response) {
-        usbMIDI.sendControlChange(MIDI_MASTER_VOLUME, (level>>6)&0x7f, midi_tx_ch); // send to MIDI controller
+    level &= 0x7f; // paranoia
+    if (midi_controller_response && midi_controller_ch > 0) {
+        usbMIDI.sendControlChange(MIDI_MASTER_VOLUME, level, midi_controller_ch); // send to MIDI controller
     }
     if (sgtl5000) {
-        sgtl5000->volume(((float)level)/8191.0);
+        sgtl5000->volume(((float)level)/127.0);
     }
     if (wm8960) {
-        wm8960->volume(((float)level)/8191.0);
+        wm8960->volume(((float)level)/127.0);
     }
 }
 
-// Expected level is 0 to 8191
-void CWKeyerShield::sidetonevolume(uint16_t level)
+void CWKeyerShield::sidetonevolume(uint8_t level)    // input level from 0 ... 127
 {
+    level &= 0x7F; // paranoia
     //
     // The input value (level) is in the range 0-31 and converted to
     // an amplitude using VolTab, such that a logarithmic pot is
     // simulated.
     //
-    if (midi_response) {
-        usbMIDI.sendControlChange(MIDI_SIDETONE_VOLUME, (level>>6)&0x7f, midi_tx_ch); // send to MIDI controller
+    if (midi_controller_response && midi_controller_ch > 0) {
+        usbMIDI.sendControlChange(MIDI_SIDETONE_VOLUME, level, midi_controller_ch); // send to MIDI controller
     }
-    // Reduce to 5 bits
-    level = (level >> 8) & 0x1f;
+    level = level >> 2;                  // reduce to 0...31
     sine.amplitude(VolTab[level]);
 }
 
-// Expected input value is 0 to 8191, maps to range 250 to about 1270Hz
-void CWKeyerShield::sidetonefrequency(uint16_t freq)
+void CWKeyerShield::sidetonefrequency(uint8_t freq)   // input freq from 0 ... 127, maps to 0 ... 1270 Hz
 {
-    sine.frequency( 250+((float)freq)/8.0 );
+    freq &= 0x7F; // paranoia
+    sine.frequency( (float)(10*freq) );
 
-    //if (midi_freq_ctrl >= 0 && midi_tx_ch > 0) {
-    //    //
-    //    // In the radio, the frequency has to be calculated as
-    //    // freq = 250 + 8*val, where val is the controller value 0<= val <= 127
-    //    //
-    //    usbMIDI.sendControlChange(midi_freq_ctrl, (freq>>6)&0x7f, midi_tx_ch); // send  to radio
-    //}
-    if (midi_response) {
-        usbMIDI.sendControlChange(MIDI_SIDETONE_FREQUENCY, (freq>>6)&0x7f, midi_tx_ch); // send to MIDI controller
+    if (midi_freq_ctrl > 0 && midi_radio_ch > 0) {
+      usbMIDI.sendControlChange(midi_freq_ctrl, freq, midi_radio_ch); // send  to radio
+    }
+    if (midi_controller_response && midi_controller_ch > 0) {
+        usbMIDI.sendControlChange(MIDI_SIDETONE_FREQUENCY, freq, midi_controller_ch); // send to MIDI controller
     }
 }
 
-// Expected speed is 1 to 127, don't use high values if not desired, no fractional CW speeds
-void CWKeyerShield::cwspeed(uint16_t speed)
+void CWKeyerShield::cwspeed(uint8_t speed)   // input speed from 0 ... 127
 {
-    if (speed == 0) speed = 1;
-    if (speed > 127) speed = 127;
+    speed &= 0x7F;              // paranoia
+    if (speed == 0) speed = 1;  // even more paranoia
 
-    //if (midi_speed_ctrl >= 0 && midi_tx_ch > 0) {
-    //    //
-    //    // In the radio, the controller value (1 <= val <= 127) encodes the speed
-    //    //
-    //    usbMIDI.sendControlChange(midi_speed_ctrl, speed&0x7f, midi_tx_ch);  // send to radio
-    //}
-    if (midi_response) {
-        usbMIDI.sendControlChange(MIDI_CW_SPEED, speed&0x7f, midi_tx_ch);    // send to MIDI controller
+    if (midi_speed_ctrl > 0 && midi_radio_ch > 0) {
+      usbMIDI.sendControlChange(midi_speed_ctrl, speed, midi_radio_ch);  // send to radio
+    }
+    if (midi_controller_response && midi_controller_ch > 0) {
+        usbMIDI.sendControlChange(MIDI_CW_SPEED, speed, midi_controller_ch);    // send to MIDI controller
     }
  }
-
-
 
 #endif

--- a/libraries/teensy/CWKeyerShield/CWKeyerShield.cpp
+++ b/libraries/teensy/CWKeyerShield/CWKeyerShield.cpp
@@ -66,10 +66,8 @@ void CWKeyerShield::setup(void)
 
     AudioInterrupts();
 
-#ifndef DL1YCF_POTS
     analogReadRes(12);
     analogReadAveraging(40);
-#endif
 
 }
 

--- a/libraries/teensy/CWKeyerShield/CWKeyerShield.h
+++ b/libraries/teensy/CWKeyerShield/CWKeyerShield.h
@@ -39,30 +39,27 @@ void keyer_leadin_set(int leadin);  // set keyer PTT lead-in time (leadin milli-
 void keyer_hang_set(int hang);      // set keyer PTT hang time (in *dotlengths*) (if using auto-PTT)
 
 enum midi_control_selection {
-  MIDI_SET_A               = 0,     // Set 7-bit accumulator A
-  MIDI_SET_B               = 1,     // Set 7-bit accumulator B
-  MIDI_SET_C               = 2,     // Set 7-bit accumulator C
+  MIDI_SET_A                    = 0,     // Set 7-bit accumulator A
+  MIDI_SET_B                    = 1,     // Set 7-bit accumulator B
+  MIDI_SET_C                    = 2,     // Set 7-bit accumulator C
 
-  MIDI_MASTER_VOLUME       = 4,     // set master volume
-  MIDI_SIDETONE_VOLUME     = 5,     // set sidetone volume
-  MIDI_SIDETONE_FREQUENCY  = 6,     // set sidetone frequency
-  MIDI_CW_SPEED            = 7,     // set CW speed
-  MIDI_ENABLE_POTS         = 8,     // enable/disable potentiometers
-  MIDI_KEYER_AUTOPTT       = 9,     // enable/disable auto-PTT from CW keyer
-  MIDI_KEYER_LEADIN        = 10,    // set Keyer lead-in time (if auto-PTT active)
-  MIDI_KEYER_HANG          = 11,    // set Keyer hang time (if auto-PTT active)
-  MIDI_RESPONSE            = 12,    // enable/disable reporting back to MIDI controller
-  MIDI_MUTE_CWPTT          = 13,    // enable/disable muting of RX audio during auto-PTT
-  MIDI_MICPTT_HWPTT        = 14,    // enable/disable that MICIN triggers the hardware PTT output
-  MIDI_CWPTT_HWPTT         = 15,    // enable/disable that CWPTT triggers the hardware PTT output
+  MIDI_MASTER_VOLUME            = 4,     // set master volume
+  MIDI_SIDETONE_VOLUME          = 5,     // set sidetone volume
+  MIDI_SIDETONE_FREQUENCY       = 6,     // set sidetone frequency
+  MIDI_CW_SPEED                 = 7,     // set CW speed
+  MIDI_ENABLE_POTS              = 8,     // enable/disable potentiometers
+  MIDI_KEYER_AUTOPTT            = 9,     // enable/disable auto-PTT from CW keyer
+  MIDI_KEYER_LEADIN             = 10,    // set Keyer lead-in time (if auto-PTT active)
+  MIDI_KEYER_HANG               = 11,    // set Keyer hang time (if auto-PTT active)
+  MIDI_RESPONSE                 = 12,    // enable/disable reporting back to MIDI controller
+  MIDI_MUTE_CWPTT               = 13,    // enable/disable muting of RX audio during auto-PTT
+  MIDI_MICPTT_HWPTT             = 14,    // enable/disable that MICIN triggers the hardware PTT output
+  MIDI_CWPTT_HWPTT              = 15,    // enable/disable that CWPTT triggers the hardware PTT output
 
-  MIDI_CONTROLLER_CH       = 16,    // set MIDI channel to/from controller
-  MIDI_RADIO_CH            = 17,    // set MIDI channel to radio
+  MIDI_SET_CHANNEL              = 16,    // set MIDI channel to/from controller
 
-  MIDI_KEYDOWN_NOTE        = 18,    // set MIDI note for key-down (to radio)
-  MIDI_PTT_NOTE            = 21,    // set MIDI note for PTT activation (to radio)
-  MIDI_SPEED_CTRL          = 22,    // set MIDI controller for cw speed (to radio)
-  MIDI_FREQ_CTRL           = 23,    // set MIDI controller for side tone frequency (to radio)
+  MIDI_KEYDOWN_NOTE             = 17,    // MIDI note for key-down
+  MIDI_PTT_NOTE                 = 18,    // MIDI note for PTT activation
 
   MIDI_WM8960_ENABLE            = 40,
   MIDI_WM8960_INPUT_LEVEL       = 41,
@@ -169,14 +166,8 @@ public:
        teensyaudiotone.sidetoneenable(onoff);
     }
 
-    void set_midi_keydown_note(int v)    { midi_keydown_note  = v; }
-    void set_midi_ptt_note(int v)        { midi_ptt_note      = v; }
-    void set_midi_speed_ctrl(int v)      { midi_speed_ctrl    = v; }
-    void set_midi_freq_ctrl(int v)       { midi_freq_ctrl     = v; }
-    void set_cwptt_mute_option(int v)    { mute_on_cwptt      = v; }
-
-    void set_midi_controller_ch(int v)   { midi_controller_ch = v; }
-    void set_midi_radio_ch(int v)        { midi_radio_ch      = v; }
+    void set_cwptt_mute_option(int v)    { mute_on_cwptt = v; }
+    void set_midi_channel(int v)         { midi_channel  = v; }
 
 
 private:
@@ -201,23 +192,13 @@ private:
     AudioConnection         *patchoutr=NULL;    // Cable "R" from side tone mixer to headphone
 
     //
-    // MIDI channels to use for communication with the controller
-    // and/or with the radio
+    // MIDI channel to use for communication with the controller
+    // *and* with the radio
     // ATTN: the 16 midi channels are numbered 1-16 (not 0-15!),
     //   since this was designed for musicians not computer scientists.
     //   So a channel value of 0 means "no communication"
     //
-    uint8_t midi_controller_ch = 2;
-    uint8_t midi_radio_ch = 0;
-
-    //
-    // MIDI note/controller values for communiation with the radio
-    // A value of zero indicates "no communication"
-    // 
-    uint8_t midi_keydown_note     = 0;
-    uint8_t midi_ptt_note         = 0;
-    uint8_t midi_speed_ctrl       = 0;
-    uint8_t midi_freq_ctrl        = 0;
+    uint8_t midi_channel = 10;
 
     // Enable/disable  that MICPTT/CWPTT triggers the hardware PTT output.
     // (both will trigger a MIDI message in either case)
@@ -232,7 +213,9 @@ private:
     uint8_t hwptt_state=0;
     uint8_t midiptt_state=0;
 
-    // Enable/disable MIDI responses back to controller
+    // Enable/disable MIDI responses to controller
+    // NOTE: "key-down", "PTT", "side tone freq" and "CW speed"
+    //       messages are sent independently of this value.
     uint8_t midi_controller_response     = 0;
 
     // Enable/disable POTS


### PR DESCRIPTION
A) changed to "single MIDI channel" operation. So it is expected that *all* MIDI messages
    sent are possibly processed by two programs on the computer (the controller and the
    SDR console).

B) Improved handling of Pots. Speed pot now has larger"delta v/delta phi" for large speeds.

C) PTT and CW-key handling now in "Shield" module

D) WM8960: Initialized microphone input (TBD for sgtl5000).

E) handling of PTT now fully functional and fully controlled, from MICPTT and from Keyer.
   For both sources, hardware PTT can individually be switched
   off while retaining MIDI PTT.

F) "midi_response" variable *cannot* switch off MIDI messages for CW, PTT, Freq, and Speed
    since they are relevant in the radio as well.

G) made mapping of MIDI values to side tone frequencies "easier"

H) The constructor now (*only*) needs  hardware settings as arguments
   but nothing else. All "dynamically changeable" parameters then can be changed
   through the corresponding interface.

I) DL1YCF_POTS removed since now obsolete.

